### PR TITLE
Fix cinematics off-by-one-pixel draw error

### DIFF
--- a/rott/cin_main.c
+++ b/rott/cin_main.c
@@ -247,9 +247,8 @@ void R_DrawFilmColumn (byte * buf)
 	int frac, fracstep;
 	byte *dest;
 
-	count = (cin_yh + 1) - cin_yl;
-	if (!count)
-		return;
+	count = cin_yh - cin_yl + 1;
+	if (count < 0) return;
 
 	dest = buf + ylookup[cin_yl];
 

--- a/rott/cin_main.c
+++ b/rott/cin_main.c
@@ -247,8 +247,9 @@ void R_DrawFilmColumn (byte * buf)
 	int frac, fracstep;
 	byte *dest;
 
-	count = cin_yh - cin_yl;
-	if (count < 0) return;
+	count = (cin_yh + 1) - cin_yl;
+	if (!count)
+		return;
 
 	dest = buf + ylookup[cin_yl];
 


### PR DESCRIPTION
It's a little hard to notice, but in the opening cinematic with the ROTT logo, you can see some missing pixels at the bottom of the logo which is not there in the DOS version. It was just a slight mistake when translating the assembly to C. This commit fixes that.

Funny enough, ROTT:LE has this bug too.