### PR TITLE
Pull ROTT data from various common install paths

### DIFF
--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -22,6 +22,10 @@
 #include "m_misc2.h"
 #include "rt_util.h"
 
+#ifndef _WIN32
+#include <pwd.h>
+#endif
+
 /*
  * storefronts
  *
@@ -233,6 +237,8 @@ static void AddStorefrontDirs(void)
 		char *prefix = getenv("XDG_DATA_HOME");
 		if (prefix == NULL)
 			prefix = getenv("HOME");
+		if (prefix == NULL)
+			prefix = getpwuid(getuid())->pw_dir;
 		if (prefix == NULL)
 			return;
 #else

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -231,35 +231,34 @@ static void AddStorefrontDirs(void)
 	struct stat st;
 	char path[1024];
 
+#ifndef _WIN32
+	char *prefix = getenv("XDG_DATA_HOME");
+
+	if (prefix == NULL)
+		prefix = getenv("HOME");
+
+	if (prefix == NULL)
+	{
+		struct passwd *pwd = getpwuid(getuid());
+
+		if (pwd == NULL)
+		{
+			perror("getpwuid");
+			return;
+		}
+
+		prefix = pwd->pw_dir;
+	}
+#else
+	const char prefix[] = "C:";
+#endif
+
 	for (int i = 0; i < num_storefront_paths; i++)
 	{
-#ifndef _WIN32
-		char *prefix = getenv("XDG_DATA_HOME");
-
-		if (prefix == NULL)
-			prefix = getenv("HOME");
-
-		if (prefix == NULL)
-		{
-			struct passwd *pwd = getpwuid(getuid());
-
-			if (pwd == NULL)
-			{
-				perror("getpwuid");
-				return;
-			}
-
-			prefix = pwd->pw_dir;
-		}
-#else
-		const char prefix[] = "C:";
-#endif
 		M_snprintf(path, sizeof(path), "%s%s", prefix, storefront_paths[i]);
 
 		if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
-		{
 			AddDataDir(M_StringDuplicate(path));
-		}
 	}
 }
 

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -46,6 +46,8 @@ static const char *storefront_paths[] = {
 	"\\Program Files (x86)\\Steam\\steamapps\\common\\Rise of the Triad Dark War\\Rise of the Triad - Dark War\\",
 	/* steam - ludicrous edition */
 	"\\Program Files (x86)\\Steam\\steamapps\\common\\Rise of the Triad - Ludicrous Edition\\assets\\",
+	/* gog - ludicrous edition */
+	"\\GOG Games\\Rise of the Triad - Ludicrous Edition\\",
 	/* gog - classic rott */
 	"\\GOG Games\\Rise of the Triad\\",
 	/* original ms-dos installers */
@@ -67,6 +69,10 @@ static const char *storefront_paths[] = {
 	"/.steam/steam/steamapps/compatdata/1421490/pfx/drive_c/users/steamuser/Saved Games/Nightdive Studios/Rise of the Triad - Ludicrous Edition/projects/",
 	/* heroic - classic rott */
 	"/Games/Heroic/Rise of the Triad/data/",
+	/* gog - ludicrous edition (wine) */
+	"/.wine/drive_c/GOG Games/Rise of the Triad - Ludicrous Edition/",
+	/* gog - ludicrous edition (native) */
+	"/GOG Games/Rise of the Triad - Ludicrous Edition/",
 	/* gog - classic rott (wine) */
 	"/.wine/drive_c/GOG Games/Rise of the Triad/",
 	/* gog - classic rott (native) */

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -235,12 +235,22 @@ static void AddStorefrontDirs(void)
 	{
 #ifndef _WIN32
 		char *prefix = getenv("XDG_DATA_HOME");
+
 		if (prefix == NULL)
 			prefix = getenv("HOME");
+
 		if (prefix == NULL)
-			prefix = getpwuid(getuid())->pw_dir;
-		if (prefix == NULL)
-			return;
+		{
+			struct passwd *pwd = getpwuid(getuid());
+
+			if (pwd == NULL)
+			{
+				perror("getpwuid");
+				return;
+			}
+
+			prefix = pwd->pw_dir;
+		}
 #else
 		const char prefix[] = "C:";
 #endif

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -43,7 +43,9 @@ static const char *storefront_paths[] = {
 	/* steam - ludicrous edition */
 	"\\Program Files (x86)\\Steam\\steamapps\\common\\Rise of the Triad - Ludicrous Edition\\assets\\",
 	/* gog - classic rott */
-	"\\GOG Games\\Rise of the Triad\\"
+	"\\GOG Games\\Rise of the Triad\\",
+	/* original ms-dos installers */
+	"\\ROTT\\"
 };
 
 #else
@@ -236,7 +238,7 @@ static void AddStorefrontDirs(void)
 #else
 		const char prefix[] = "C:";
 #endif
-		snprintf(path, sizeof(path), "%s%s", prefix, storefront_paths[i]);
+		M_snprintf(path, sizeof(path), "%s%s", prefix, storefront_paths[i]);
 
 		if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
 		{

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -238,10 +238,7 @@ static void AddStorefrontDirs(void)
 	char path[1024];
 
 #ifndef _WIN32
-	char *prefix = getenv("XDG_DATA_HOME");
-
-	if (prefix == NULL)
-		prefix = getenv("HOME");
+	char *prefix = getenv("HOME");
 
 	if (prefix == NULL)
 	{

--- a/rott/rt_menu.c
+++ b/rott/rt_menu.c
@@ -7976,7 +7976,7 @@ void ShowBattleOptions
       }
    ShowBattleOption( inmenu, PosX, PosY, 0, 9, "Danger Damage", string );
 
-   GetMapFileName ( text );
+   GetMapFileName ( text, sizeof(text) );
    ShowBattleOption( inmenu, PosX, PosY, 0, 10, "Filename", text );
 
    itoa( numplayers, text, 10 );

--- a/rott/rt_net.c
+++ b/rott/rt_net.c
@@ -2420,7 +2420,7 @@ void SendGameDescription( void )
    desc->teamplay = gamestate.teamplay;
    memcpy( &desc->SpecialsTimes, &gamestate.SpecialsTimes, sizeof( specials ) );
    BATTLE_GetOptions( &( desc->options ) );
-   GetMapFileName( &(desc->battlefilename[0]) );
+   GetMapFileName( &(desc->battlefilename[0]), sizeof(desc->battlefilename) );
    desc->randomseed=GetRNGindex ( );
    gamestate.randomseed=desc->randomseed;
    desc->ludicrousgibs=battlegibs;

--- a/rott/rt_ted.c
+++ b/rott/rt_ted.c
@@ -1624,25 +1624,18 @@ void GetMapFileInfo
 */
 void GetMapFileName ( char * filename, size_t n )
 {
-	char *src, *ptr;
+	const char *src;
 
 	if (BATTLEMODE && BattleLevels.avail == true)
-		src = BattleLevels.file;
+		src = M_BaseName(BattleLevels.file);
 	else if (GameLevels.avail == true)
-		src = GameLevels.file;
-	else if ( BATTLEMODE )
-		src = BATTMAPS;
+		src = M_BaseName(GameLevels.file);
+	else if (BATTLEMODE)
+		src = M_BaseName(BATTMAPS);
 	else
-		src = ROTTMAPS;
+		src = M_BaseName(ROTTMAPS);
 
-	ptr = strrchr(src, PATH_SEP_CHAR);
-
-	if (ptr == NULL)
-		ptr = src;
-	else
-		ptr = ptr + 1;
-
-	strncpy(filename,ptr,n);
+	strncpy(filename,src,n);
 }
 
 /*

--- a/rott/rt_ted.c
+++ b/rott/rt_ted.c
@@ -1622,24 +1622,27 @@ void GetMapFileInfo
 =
 ======================
 */
-void GetMapFileName ( char * filename )
+void GetMapFileName ( char * filename, size_t n )
 {
-   if ( ( BATTLEMODE ) && (BattleLevels.avail == true) )
-      {
-      strcpy(filename,BattleLevels.file);
-      }
-   else if (GameLevels.avail == true)
-      {
-      strcpy(filename,GameLevels.file);
-      }
-   else if ( BATTLEMODE )
-      {
-      strcpy(filename,BATTMAPS);
-      }
-   else
-      {
-      strcpy(filename,ROTTMAPS);
-      }
+	char *src, *ptr;
+
+	if (BATTLEMODE && BattleLevels.avail == true)
+		src = BattleLevels.file;
+	else if (GameLevels.avail == true)
+		src = GameLevels.file;
+	else if ( BATTLEMODE )
+		src = BATTMAPS;
+	else
+		src = ROTTMAPS;
+
+	ptr = strrchr(src, PATH_SEP_CHAR);
+
+	if (ptr == NULL)
+		ptr = src;
+	else
+		ptr = ptr + 1;
+
+	strncpy(filename,ptr,n);
 }
 
 /*
@@ -1673,7 +1676,7 @@ unsigned short GetMapCRC
    RTLMAP RTLMap;
    size_t mapsoffset;
 
-   GetMapFileName( &filename[ 0 ] );
+   GetMapFileName( &filename[ 0 ], sizeof(filename) );
    CheckRTLVersion( filename );
    filehandle = SafeOpenRead( filename );
    mapsoffset = GetMapArrayOffset( filehandle );

--- a/rott/rt_ted.h
+++ b/rott/rt_ted.h
@@ -168,7 +168,7 @@ void PrintMapStats (void);
 void PrintTileStats (void);
 
 void GetMapInfo (mapfileinfo_t * mapinfo);
-void GetMapFileName ( char * filename );
+void GetMapFileName ( char * filename, size_t n );
 void SetBattleMapFileName ( char * filename );
 unsigned short GetMapCRC ( int num );
 


### PR DESCRIPTION
Heavily work in progress. It builds under Mingw, but it doesn't do any (much needed) Windows Registry checks for things such as the Steam directory and maybe others. For both Linux and Windows, it just queries the default installation paths from the various storefronts for each platform. It works, but it's not super elegant or foolproof. This does not conflict with the XDG paths or any others.

This also needs to be modified to account for where the game could be installed with GOG under Mac OS X.