### PR TITLE
Small datadirs improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ endif()
 
 add_executable(${TARADINO_EXEC} ${TARADINO_SOURCES})
 target_link_libraries(${TARADINO_EXEC} PRIVATE SDL2::Main SDL2::Mixer)
-target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_STRING="${TARADINO_EXEC} ${CMAKE_PROJECT_VERSION}")
-target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_TARNAME="${TARADINO_EXEC}")
+target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_STRING="${TARADINO_TITLE} ${CMAKE_PROJECT_VERSION}")
+target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_TARNAME="${CMAKE_PROJECT_NAME}")
 
 if(${TARADINO_SHAREWARE})
 	target_compile_definitions(${TARADINO_EXEC} PRIVATE SHAREWARE=1)

--- a/rott/rt_datadir.c
+++ b/rott/rt_datadir.c
@@ -68,13 +68,15 @@ char *GetPrefDir (void)
 
         M_MakeDirectory(dir);
 
-#if !(SHAREWARE == 1)
         result = dir;
+#if !(SHAREWARE == 1)
         dir = M_StringJoin(result, "darkwar", PATH_SEP_STR, NULL);
+#else
+        dir = M_StringJoin(result, "huntbgin", PATH_SEP_STR, NULL);
+#endif
         free(result);
 
         M_MakeDirectory(dir);
-#endif
     }
 
     return dir;


### PR DESCRIPTION
Instead of saving configuration files inconsistently between shareware and registered, this PR ensures that they are saved into the same Taradino folder, in a subfolder for the name of the WAD. For registered, this is "darkwar" and for shareware this is "huntbgin". This can be expanded later for any other game WADs that could be loaded (i.e. huntbgn2.wad, or Extreme ROTT).