### PR TITLE
First steps to fixing gamepad/joystick support

### DIFF
--- a/rott/rt_in.c
+++ b/rott/rt_in.c
@@ -85,7 +85,6 @@ static int sdl_mouse_delta_y = 0;
 static unsigned short sdl_mouse_button_mask = 0;
 static int sdl_total_sticks = 0;
 static unsigned short *sdl_stick_button_state = NULL;
-static unsigned short sdl_sticks_joybits = 0;
 static int sdl_mouse_grabbed = 0;
 extern boolean sdl_fullscreen;
 

--- a/rott/rt_in.c
+++ b/rott/rt_in.c
@@ -398,8 +398,6 @@ static int sdl_joystick_button_filter(const SDL_Event *event)
 		sdl_stick_button_state[event->jbutton.which] &= ~(1 << event->jbutton.button);
 	}
 
-	fflush(stdout);
-
 	return 0;
 }
 

--- a/rott/rt_in.c
+++ b/rott/rt_in.c
@@ -391,12 +391,10 @@ static int sdl_joystick_button_filter(const SDL_Event *event)
 
 	if (event->type == SDL_JOYBUTTONDOWN)
 	{
-		printf("SDL_JOYBUTTONDOWN: %d\n", event->jbutton.button);
 		sdl_stick_button_state[event->jbutton.which] |= (1 << event->jbutton.button);
 	}
 	else if (event->type == SDL_JOYBUTTONUP)
 	{
-		printf("SDL_JOYBUTTONUP: %d\n", event->jbutton.button);
 		sdl_stick_button_state[event->jbutton.which] &= ~(1 << event->jbutton.button);
 	}
 


### PR DESCRIPTION
The first 4 buttons are now recognized by joystick index, and the joystick ABS value is clamped to the range that ROTT expects. It's sorta playable! But you can't switch weapons or anything. Not sure how that was meant to work on a traditional gamepad. I will keep working on first-class support when I have time.