### PR TITLE
Use SDL_LockTexture() instead of SDL_UpdateTexture()

### DIFF
--- a/rott/modexlib.c
+++ b/rott/modexlib.c
@@ -106,7 +106,6 @@ void SetShowCursor(int show)
 void GraphicsMode ( void )
 {
 	uint32_t flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
-	uint32_t pixel_format;
 
 	if (SDL_InitSubSystem (SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)
 	{
@@ -141,12 +140,11 @@ void GraphicsMode ( void )
 	                                   0, 0, 0, 0);
 	SDL_FillRect(sdl_surface, NULL, 0);
 
-	pixel_format = SDL_GetWindowPixelFormat(screen);
-	argbbuffer = SDL_CreateRGBSurfaceWithFormatFrom(NULL, iGLOBAL_SCREENWIDTH, iGLOBAL_SCREENHEIGHT, 0, 0, pixel_format);
+	argbbuffer = SDL_CreateRGBSurfaceWithFormatFrom(NULL, iGLOBAL_SCREENWIDTH, iGLOBAL_SCREENHEIGHT, 0, 0, SDL_PIXELFORMAT_ARGB8888);
 
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 	texture = SDL_CreateTexture(renderer,
-	                            pixel_format,
+	                            SDL_PIXELFORMAT_ARGB8888,
 	                            SDL_TEXTUREACCESS_STREAMING,
 	                            iGLOBAL_SCREENWIDTH, iGLOBAL_SCREENHEIGHT);
 

--- a/rott/modexlib.c
+++ b/rott/modexlib.c
@@ -387,6 +387,8 @@ void VL_DePlaneVGA (void)
 
 void VH_UpdateScreen (void)
 { 	
+	void *dst_pixels;
+	int dst_pitch;
 
 	if (StretchScreen){//bna++
 		StretchMemPicture ();
@@ -394,7 +396,13 @@ void VH_UpdateScreen (void)
 		DrawCenterAim ();
 	}
 	SDL_LowerBlit(VL_GetVideoSurface(), &blit_rect, argbbuffer, &blit_rect);
-	SDL_UpdateTexture(texture, NULL, argbbuffer->pixels, argbbuffer->pitch);
+
+	if (SDL_LockTexture(texture, NULL, &dst_pixels, &dst_pitch) == 0)
+	{
+		SDL_memcpy(dst_pixels, argbbuffer->pixels, argbbuffer->pitch * argbbuffer->h);
+		SDL_UnlockTexture(texture);
+	}
+
 	SDL_RenderClear(renderer);
 	SDL_RenderCopy(renderer, texture, NULL, NULL);
 	SDL_RenderPresent(renderer);
@@ -411,13 +419,22 @@ void VH_UpdateScreen (void)
 
 void XFlipPage ( void )
 {
- 	if (StretchScreen){//bna++
+	void *dst_pixels;
+	int dst_pitch;
+
+	if (StretchScreen){//bna++
 		StretchMemPicture ();
 	}else{
 		DrawCenterAim ();
 	}
    SDL_LowerBlit(sdl_surface, &blit_rect, argbbuffer, &blit_rect);
-   SDL_UpdateTexture(texture, NULL, argbbuffer->pixels, argbbuffer->pitch);
+
+   if (SDL_LockTexture(texture, NULL, &dst_pixels, &dst_pitch) == 0)
+   {
+	   SDL_memcpy(dst_pixels, argbbuffer->pixels, argbbuffer->pitch * argbbuffer->h);
+	   SDL_UnlockTexture(texture);
+   }
+
    SDL_RenderClear(renderer);
    SDL_RenderCopy(renderer, texture, NULL, NULL);
    SDL_RenderPresent(renderer);

--- a/rott/vgatext.c
+++ b/rott/vgatext.c
@@ -162,10 +162,7 @@ int vgatext_main(SDL_Window *window, Uint16 *screen)
 	// main loop
 	while (!SDL_QuitRequested())
 	{
-		void *dst_pixels;
-		int dst_pitch;
 		SDL_Event event;
-
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type == SDL_KEYDOWN || event.type == SDL_MOUSEBUTTONDOWN)
@@ -183,12 +180,7 @@ int vgatext_main(SDL_Window *window, Uint16 *screen)
 			next += BLINK_HZ;
 		}
 
-		if (SDL_LockTexture(texture, NULL, &dst_pixels, &dst_pitch) == 0)
-		{
-			SDL_memcpy(dst_pixels, (*windowsurface)->pixels, (*windowsurface)->pitch * (*windowsurface)->h);
-			SDL_UnlockTexture(texture);
-		}
-
+		SDL_UpdateTexture(texture, NULL, (*windowsurface)->pixels, (*windowsurface)->pitch);
 		SDL_RenderClear(renderer);
 		SDL_RenderCopy(renderer, texture, NULL, NULL);
 		SDL_RenderPresent(renderer);

--- a/rott/vgatext.c
+++ b/rott/vgatext.c
@@ -162,7 +162,10 @@ int vgatext_main(SDL_Window *window, Uint16 *screen)
 	// main loop
 	while (!SDL_QuitRequested())
 	{
+		void *dst_pixels;
+		int dst_pitch;
 		SDL_Event event;
+
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type == SDL_KEYDOWN || event.type == SDL_MOUSEBUTTONDOWN)
@@ -180,7 +183,12 @@ int vgatext_main(SDL_Window *window, Uint16 *screen)
 			next += BLINK_HZ;
 		}
 
-		SDL_UpdateTexture(texture, NULL, (*windowsurface)->pixels, (*windowsurface)->pitch);
+		if (SDL_LockTexture(texture, NULL, &dst_pixels, &dst_pitch) == 0)
+		{
+			SDL_memcpy(dst_pixels, (*windowsurface)->pixels, (*windowsurface)->pitch * (*windowsurface)->h);
+			SDL_UnlockTexture(texture);
+		}
+
 		SDL_RenderClear(renderer);
 		SDL_RenderCopy(renderer, texture, NULL, NULL);
 		SDL_RenderPresent(renderer);


### PR DESCRIPTION
SDL2 documentation states that this is the preferred method if you want fast(er) screen updates. I don't know if there's any perceivable difference on my machine, but it's probably best practice anyways.