### PR TITLE
Apply various changes from gamesrc-ver-recreation

### DIFF
--- a/rott/_rt_acto.h
+++ b/rott/_rt_acto.h
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef _rt_actor_private
 #define _rt_actor_private
 
-#define MAXGIBS            600
+#define MAXGIBS            200
 #define HAAPT              24
 #define VAAPT              24
 #define GODHAPT            1024
@@ -43,7 +43,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define HIGHFALLCLIPZ      -5
 #define LOWRISECLIPZ       (nominalheight)
 #define HIGHRISECLIPZ      64
-#define NORMALGIBSPEED     0x2f00
+#define NORMALGIBSPEED     0x1f00
 
 #define FL_PLEADING        0x400
 #define FL_EYEBALL         0x400

--- a/rott/rt_actor.c
+++ b/rott/rt_actor.c
@@ -3283,9 +3283,7 @@ void SpawnSuperFatalityGibs(objtype *ob,objtype *attacker)
       else
          {
          MISCVARS->randgibspeed = true;
-//         SpawnParticles(ob,GUTS,75);
-//MED
-         SpawnParticles(ob,GUTS,150);
+         SpawnParticles(ob,GUTS,75);
          MISCVARS->randgibspeed = false;
          }
       SpawnParticles(ob,GUTS,40);
@@ -3755,9 +3753,7 @@ void SpawnParticles(objtype*ob,int which,int numparticles)
                      (randadj<<4);
          dz = 100 + (randadj<<3);
 
-//MED
-//         nspeed = 0x2800 + (randadj<<7);
-         nspeed = 0x2800;
+         nspeed = 0x2800 + (randadj<<7);
          randphi = atan2_appx(FindDistance(dx,dy),dz<<10);
          }
 
@@ -3778,9 +3774,9 @@ void SpawnParticles(objtype*ob,int which,int numparticles)
       new->temp2 = gibtype;
       new->temp3 = (MISCVARS->gibgravity == -1)?(GRAVITY):(MISCVARS->gibgravity);
 
-      new->speed = nspeed>>1;
-//      if (MISCVARS->randgibspeed == true)
-//         new->speed += (randadj << 11);
+      new->speed = nspeed;
+      if (MISCVARS->randgibspeed == true)
+         new->speed += (randadj << 11);
          //if (ob->state == &s_snakefireworks)
       new->z = ob->z;
       Fix(randphi);

--- a/rott/rt_ted.c
+++ b/rott/rt_ted.c
@@ -5157,8 +5157,6 @@ void SetupGameLevel (void)
    
 	if (gamestate.SpawnEluder || gamestate.SpawnDeluder)
       {
-//MED
-      for (i=0;i<25;i++)
          RespawnEluder();
       }
 


### PR DESCRIPTION
I went through the code at https://bitbucket.org/gamesrc-ver-recreation/rott and changed the code in various places where differences were indicated between the commercial release and source release, focusing only on gameplay changes. This fixes the E1A1 demo desync. I haven't tested the other included demos yet.