### PR TITLE
Remove BNA weaponscale

### DIFF
--- a/rott/rt_cfg.c
+++ b/rott/rt_cfg.c
@@ -64,7 +64,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 //******************************************************************************
 
-extern int G_weaponscale;
 extern boolean iG_aimCross;
 
 boolean WriteSoundFile   = true;
@@ -439,17 +438,6 @@ boolean ParseConfigFile (void)
       // Read in ViewSize
 
       ReadInt("ViewSize",&viewsize);
-
-      // Read in Weaponscale
-
-      ReadInt("Weaponscale",&G_weaponscale);//bna added
-	   if ((G_weaponscale <150)||(G_weaponscale>600)){
-		   if (iGLOBAL_SCREENWIDTH == 320){
-				G_weaponscale=168;
-		   }else if (iGLOBAL_SCREENWIDTH == 640){
-				G_weaponscale=299;
-		   }
-	   }
 
       // Read in MouseAdjustment
 
@@ -1622,23 +1610,6 @@ void WriteConfig (void)
    SafeWriteString(file,"; Size of View port.\n");
    SafeWriteString(file,"; (smallest) 0 - 10 (largest)\n");
    WriteParameter(file,"ViewSize         ",viewsize);
-
-   // Write out WEAPONSCALE  bna added
-
-   SafeWriteString(file,"\n;\n");
-   SafeWriteString(file,"; Size of Weaponscale.\n");
-   SafeWriteString(file,"; (smallest) 150 - 600 (largest)\n");
-   G_weaponscale = (weaponscale * 168 )/65536;
-
-   if ((G_weaponscale <150)||(G_weaponscale>600)){
-	   if (iGLOBAL_SCREENWIDTH == 320){
-			G_weaponscale=168;
-	   }else if (iGLOBAL_SCREENWIDTH == 640){
-			G_weaponscale=299;
-	   }
-   }
-   WriteParameter(file,"Weaponscale         ",G_weaponscale);
-
 
    // Write out MouseAdjustment
 

--- a/rott/rt_main.c
+++ b/rott/rt_main.c
@@ -134,7 +134,6 @@ void SetRottScreenRes (int Width, int Height);
 
 //extern int G_argc;
 //extern char G_argv[30][80];
-int G_weaponscale;
 extern int iDropDemo;
 extern boolean iG_aimCross;
 extern boolean sdl_fullscreen;
@@ -509,7 +508,6 @@ void CheckCommandLineParameters( void )
       printf ("         Shift            - Run/Turn faster\n");
       printf ("         Space            - Use/Open\n");
       printf ("         1-4              - Choose Weapon\n");
-      printf ("         5-6              - Scale Weapon Up/Down\n");
       printf ("         Enter            - Swap Weapon\n");
       printf ("         Backspace        - Turn 180\n");
       printf ("         Delete           - Drop Weapon\n");

--- a/rott/rt_playr.c
+++ b/rott/rt_playr.c
@@ -2537,18 +2537,6 @@ void PollControls (void)
    if (Keyboard[sc_Insert] && Keyboard[sc_X]){
 	      AddExitCommand();
    }
-//bna section
-   if (Keyboard[sc_5]){
-	//	 SetTextMode (  );
-      weaponscale +=  1000;
-	  //testval++;
-   }
-   if (Keyboard[sc_6]){
-	//	 SetTextMode (  );
-      weaponscale -=  1000;
-	  	//  testval--;
-   }
-//bna section end 
 
 
 

--- a/rott/rt_view.c
+++ b/rott/rt_view.c
@@ -52,9 +52,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 =============================================================================
 */
-extern int G_weaponscale;
-
-
 int    StatusBar = 0;
 int    lightninglevel=0;
 boolean  lightning=false;


### PR DESCRIPTION
Removes weapon scaling code added by BNA:

- Removes line in help describing how to change weapon scale
- Removes weapon scaling from keyboard input
- Removes G_weaponscale config variable