### PR TITLE
set project C standard to C17 unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ target_link_libraries(${TARADINO_EXEC} PRIVATE SDL2::Main SDL2::Mixer)
 target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_STRING="${TARADINO_TITLE} ${CMAKE_PROJECT_VERSION}")
 target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_TARNAME="${CMAKE_PROJECT_NAME}")
 
-if(MSVC)
-	set_property(TARGET ${TARADINO_EXEC} PROPERTY C_STANDARD 17)
+set_property(TARGET ${TARADINO_EXEC} PROPERTY C_STANDARD 17)
+if (MSVC)
 	# silence warnings about POSIX functions
 	target_compile_options(${TARADINO_EXEC} PUBLIC -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -Dstrcasecmp=_stricmp -Dalloca=_alloca)
 	# silence unsigned/signed and integer truncation warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(${TARADINO_EXEC} PRIVATE SDL2::Main SDL2::Mixer)
 target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_STRING="${TARADINO_TITLE} ${CMAKE_PROJECT_VERSION}")
 target_compile_definitions(${TARADINO_EXEC} PRIVATE PACKAGE_TARNAME="${CMAKE_PROJECT_NAME}")
 
-set_property(TARGET ${TARADINO_EXEC} PROPERTY C_STANDARD 17)
+set_property(TARGET ${TARADINO_EXEC} PROPERTY C_STANDARD 99)
 if (MSVC)
 	# silence warnings about POSIX functions
 	target_compile_options(${TARADINO_EXEC} PUBLIC -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -Dstrcasecmp=_stricmp -Dalloca=_alloca)

--- a/rott/rt_def.h
+++ b/rott/rt_def.h
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include "develop.h"
 #include "rt_fixed.h"
 
@@ -286,9 +287,7 @@ typedef unsigned char           byte;
 //////////////////      GLOBAL ENUMERATED TYPES    ///////////////////////
 
 typedef unsigned char boolean;
-enum {
-  false, true
-};
+// true and false are defined by stdbool
 
 typedef enum {
 		  east,


### PR DESCRIPTION
As of GCC 15, gnu23 is now the default C standard, which breaks taradino (as `true` and `false` are reserved keywords in C23). Taradino is already compiled using c17 under MSVC. As two of the three major C compilers now require setting the C standard in order to build the project, I would recommend setting the standard unconditionally, as I am not aware of any supported platforms this would break, hence the PR. 

If setting the standard across the board is, in fact, a problem, I can rewrite the PR to check for either GCC or msvc instead.